### PR TITLE
Fixed date sorting issue on Feedings table

### DIFF
--- a/controllers/feedings controller.js
+++ b/controllers/feedings controller.js
@@ -6,15 +6,14 @@ const excel = require('exceljs');
 const Sentry = require("@sentry/node");
 
 
-exports.get_feedings = function (req, res) {
-    Feeding.find({}, function (err, feedings) {
-        if (err) {
-            Sentry.captureException(err);
-            res.render('error',{message:'Unable to fetch feedings',error: err});
-        } else {
-            res.render('feedings/feedings', { data: feedings, title: 'Feedings' });
-        }
-    })
+exports.get_feedings = async function (req, res) {
+
+    const getFeedings = await Feeding.find({}).sort({Date: 'desc'});
+
+  
+        res.render('feedings/feedings', { data: getFeedings, title: 'Feedings' });
+
+              
 }
 
 exports.get_export_feedings_page = function (req, res) {

--- a/views/feedings/feedings.ejs
+++ b/views/feedings/feedings.ejs
@@ -112,7 +112,10 @@
           $(document).ready(function () {
             $('#feedingsTable').DataTable({
               responsive: true,
-              order: [[0, "desc"]]
+              order: [[0, "desc"]],
+              columnDefs: [
+    { "type": "date", "targets": 0 }
+  ]
             });
           });
         </script>


### PR DESCRIPTION
Fixed a date sorting issue on the Feedings table by adding some code to the front end on the Datatable script and also added a sorting function to the backend so that when the data is passed to the frontend, the data is already sorted and jquery doesn't have to do any sorting.